### PR TITLE
add check if `function` folder exist? then delete

### DIFF
--- a/src/utils/fileUtils.js
+++ b/src/utils/fileUtils.js
@@ -14,6 +14,7 @@ const yaml = require('js-yaml');
 const path = require('path');
 const os = require('os');
 const exec = promisify(require('child_process').exec);
+const rimraf = require("rimraf"); // similar to `rm -Rf` for recursive remove
 
 const homedir = os.homedir();
 
@@ -164,14 +165,15 @@ module.exports = {
   copyFile,
   createDirectory,
   createJSONFile,
+  exec,
   exists,
   getMashrPath,
-  readFile,
-  writeFile,
-  readYaml,
-  writeResources,
-  readResources,
-  removeResource,
   mkdir,
-  exec,
+  readFile,
+  readResources,
+  readYaml,
+  removeResource,
+  rimraf,
+  writeFile,
+  writeResources,
 };


### PR DESCRIPTION
Added a check to `createCloudFunction.js` to see if the `function` folder
already exists before trying to create it. If it does exist, then the
folder is deleted. This prevents an error when using `mkdir` to create a
folder with the same name as a folder that already exists.

Also added a few console logs to report when the folder is being deleted
and created.

Co-authored-by: Mat Sachs <matochondrion@gmail.com>
Co-authored-by: Linus Phan <phanlinus@gmail.com>
Co-authored-by: Jacob Coker <jacobleecd@gmail.com>